### PR TITLE
initialize時に下書きファイルを同期対象に含めるか選択できるようにする

### DIFF
--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -46,7 +46,8 @@ jobs:
           commit-message: |
             initialize
           body: |
-            initialize
+            はてなブログから取得した記事データを commit しました
+            **${{ inputs.is_draft_included && '下書き記事を含んでいますので公開リポジトリの場合はマージは慎重に行ってください' || '公開記事のみが対象となっています'}}**
           labels: |
             skip-push
           delete-branch: true

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -3,6 +3,9 @@ name: "[Reusable workflows] initialize"
 on:
   workflow_call:
     inputs:
+      is_draft_included:
+        default: true
+        type: boolean
       BLOG_DOMAIN:
         required: true
         type: string
@@ -25,7 +28,16 @@ jobs:
         run: |
           blogsync pull ${{ inputs.BLOG_DOMAIN }}
       - name: move draft and update metadata
+        if: inputs.is_draft_included == true
         uses: hatena/hatenablog-workflows/.github/actions/move-draft-and-update-metadata@v1
+      - name: delete draft files
+        if: inputs.is_draft_included == false
+        run: |
+          target=$(git ls-files -mo --exclude-standard | xargs grep -xl 'Draft: true')
+          IFS=" " read -r -a draft_files <<< "$(echo "$target" | xargs)"
+          for file in "${draft_files[@]}"; do
+            rm "$file"
+          done
       - name: create pull request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
## 背景

- workflow 実施時に未公開状態の下書き記事が反映されることに一見気づきにくい＆同期不要なユースケースがあり得る

## 実装内容

- initialize workflow 実行時に下書き記事を同期対象に含めるか選択できるようにした

### 注意事項

- 利用するには[Boilerplate](https://github.com/hatena/Hatena-Blog-Workflows-Boilerplate)のinputsを修正する必要があります
- 元のインターフェースの場合も動作するように作成しております