### PR TITLE
blogsyncのバージョンをv0.13.5に固定

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: setup blogsync
       uses: x-motemen/blogsync@v0.13.5
       with:
-        version: latest
+        version: "v0.13.5"
     - name: restore mtime
       run: |
         git restore-mtime

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,7 +8,7 @@ runs:
         sudo apt-get install -y git-restore-mtime
       shell: bash
     - name: setup blogsync
-      uses: x-motemen/blogsync@v0
+      uses: x-motemen/blogsync@v0.13.5
       with:
         version: latest
     - name: restore mtime


### PR DESCRIPTION
## 背景

- blogsyncの更新に伴い, 一部アクションの動作が不安定になっていることが発覚したためバージョンを変更する

## 実装内容

- workflowで利用しているblogsyncのバージョンをlatestから特定のバージョンに一旦固定する
