### PR TITLE
fix: 下書き記事が存在しない際にエラーになる現象を修正

### DIFF
--- a/.github/actions/move-draft-and-update-metadata/action.yaml
+++ b/.github/actions/move-draft-and-update-metadata/action.yaml
@@ -5,10 +5,13 @@ runs:
   steps:
     - name: move draft and update metadata
       run: |
-        draft_files=($(grep -xl 'Draft: true' $(git ls-files -mo --exclude-standard)))
+        draft_files=($(grep -xl 'Draft: true' $(git ls-files -mo --exclude-standard) || echo ""))
+        if [[ ${#draft_files[@]} -eq 0 ]]; then
+          exit 0
+        fi
         for file in ${draft_files[@]}; do
           entry_id=$(yq --front-matter=extract '.EditURL' "$file" | grep -oP '[^/]+\d$')
-          yq --front-matter=process -i 'del(.Date,.URL)' "$file" 
+          yq --front-matter=process -i 'del(.Date,.URL)' "$file"
           mv "$file" "draft_entries/$entry_id.${file##*.}"
         done
       shell: bash

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -33,11 +33,13 @@ jobs:
       - name: delete draft files
         if: inputs.is_draft_included == false
         run: |
-          target=$(git ls-files -mo --exclude-standard | xargs grep -xl 'Draft: true')
-          IFS=" " read -r -a draft_files <<< "$(echo "$target" | xargs)"
-          for file in "${draft_files[@]}"; do
-            rm "$file"
-          done
+          target=$(git ls-files -mo --exclude-standard | xargs grep -xl 'Draft: true' || echo "")
+          if [[ ! -z "$target" ]]; then
+            IFS=" " read -r -a draft_files <<< "$(echo "$target" | xargs)"
+            for file in "${draft_files[@]}"; do
+              rm "$file"
+            done
+          fi
       - name: create pull request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
Closes #23

`.github/workflows/initialize.yaml`について、対象ファイルがない場合に、xargs コマンドが受け取る引数がなく、エラーが発生

(修正前)
```yaml
      - name: delete draft files
        if: inputs.is_draft_included == false
        run: |
          target=$(git ls-files -mo --exclude-standard | xargs grep -xl 'Draft: true')
          IFS=" " read -r -a draft_files <<< "$(echo "$target" | xargs)"
          for file in "${draft_files[@]}"; do
            rm "$file"
          done
```

修正後は以下の通り、下書き記事があった場合にのみ、ファイル削除を行なっています。

(修正後)
```yaml
          target=$(git ls-files -mo --exclude-standard | xargs grep -xl 'Draft: true' || echo "")
          if [[ ! -z "$target" ]]; then
            IFS=" " read -r -a draft_files <<< "$(echo "$target" | xargs)"
            for file in "${draft_files[@]}"; do
              rm "$file"
            done
          fi
```

`.github/actions/move-draft-and-update-metadata/action.yaml`について、こちらも対象ファイルがない場合に、draft_filesが空になることでエラーが発生していました。

(修正前)
```yaml

    - name: move draft and update metadata
      run: |
        draft_files=($(grep -xl 'Draft: true' $(git ls-files -mo --exclude-standard)))
        for file in ${draft_files[@]}; do
          entry_id=$(yq --front-matter=extract '.EditURL' "$file" | grep -oP '[^/]+\d$')
          yq --front-matter=process -i 'del(.Date,.URL)' "$file" 
          mv "$file" "draft_entries/$entry_id.${file##*.}"
        done
      shell: bash
```

修正後は以下のように、空だった場合に処理をスキップするようにしています。

(修正後)
```yaml
        draft_files=($(grep -xl 'Draft: true' $(git ls-files -mo --exclude-standard) || echo ""))
        if [[ ${#draft_files[@]} -eq 0 ]]; then
          exit 0
        fi
        for file in ${draft_files[@]}; do
          entry_id=$(yq --front-matter=extract '.EditURL' "$file" | grep -oP '[^/]+\d$')
          yq --front-matter=process -i 'del(.Date,.URL)' "$file"
          mv "$file" "draft_entries/$entry_id.${file##*.}"
        done
```