### PR TITLE
blogsyncのバージョンのdefaultで最新のものをみるように修正＆呼び出し時に指定できるようにする

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,4 +1,4 @@
-name: Setup blogsync
+name: Setup
 
 runs:
   using: "composite"
@@ -8,9 +8,9 @@ runs:
         sudo apt-get install -y git-restore-mtime
       shell: bash
     - name: setup blogsync
-      uses: x-motemen/blogsync@v0.13.5
+      uses: x-motemen/blogsync@v0
       with:
-        version: "v0.13.5"
+        version: latest
     - name: restore mtime
       run: |
         git restore-mtime


### PR DESCRIPTION
## 背景

- blogsyncのバージョンアップに伴って一部のworkflowの動作に影響があったため一時的にblogsyncのバージョンを固定していた
  - https://github.com/hatena/hatenablog-workflows/pull/21
- これは下記のPRにて修正されているので最新バージョンを利用するように修正する
  - https://github.com/x-motemen/blogsync/pull/99

## 実装内容

- workflowで利用しているblogsyncのバージョンを latest に戻す
