### PR TITLE
タイトルからファイルを特定する処理の不備を修正

### DIFF
--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -1,8 +1,7 @@
-name: pull draft by title
+name: create draft pull request
 
 inputs:
   title:
-    description: draft entry title
     required: true
   BLOG_DOMAIN:
     required: true

--- a/.github/actions/pull-draft-by-title/action.yaml
+++ b/.github/actions/pull-draft-by-title/action.yaml
@@ -6,31 +6,18 @@ inputs:
     required: true
   BLOG_DOMAIN:
     required: true
+  ENTRY_PATH:
+    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: pull
+    - name: set entry variables
+      id: set-entry-variables
       run: |
-        blogsync pull ${{ inputs.BLOG_DOMAIN }}
-      shell: bash
-    - name: find entry
-      id: find-entry
-      run: |
-        files=($(git ls-files -o --exclude-standard))
-        for file in ${files[@]}; do
-          title=$(yq --front-matter=extract '.Title' "$file")
-          if [[ "$title" == ${{ inputs.title }} ]]; then
-            entry_path="$file"
-          fi
-        done
-        if [[ -z "$entry_path" ]]; then
-          echo "Error: No draft entry titled ${{ inputs.title }} was found"
-          exit 1
-        fi
-        echo "EDIT_URL=$(yq --front-matter=extract '.EditURL' "$entry_path")" >> $GITHUB_OUTPUT
-        echo "ENTRY_ID=$(yq --front-matter=extract '.EditURL' "$entry_path" | grep -oP '[^/]+\d$')" >> $GITHUB_OUTPUT
-        echo "PREVIEW_URL=$(yq --front-matter=extract '.PreviewURL' "$entry_path")" >> $GITHUB_OUTPUT
+        echo "EDIT_URL=$(yq --front-matter=extract '.EditURL' ${{ inputs.ENTRY_PATH }})" >> $GITHUB_OUTPUT
+        echo "ENTRY_ID=$(yq --front-matter=extract '.EditURL' ${{ inputs.ENTRY_PATH }} | grep -oP '[^/]+\d$')" >> $GITHUB_OUTPUT
+        echo "PREVIEW_URL=$(yq --front-matter=extract '.PreviewURL' ${{ inputs.ENTRY_PATH }})" >> $GITHUB_OUTPUT
       shell: bash
     - name: set owner
       id: set-owner
@@ -39,11 +26,11 @@ runs:
         if [[ "$owner" == 'null' ]]; then
           owner=$(yq ".[\"${{ inputs.BLOG_DOMAIN }}\"].username" blogsync.yaml)
         fi
-        echo "OWNER_NAME="$owner"" >> $GITHUB_OUTPUT
+        echo "OWNER_NAME=$owner" >> $GITHUB_OUTPUT
       shell: bash
     - name: delete other files
       run: |
-        delete_files=($(grep -xL "EditURL: ${{ steps.find-entry.outputs.EDIT_URL }}" $(git ls-files -mo --exclude-standard)))
+        delete_files=($(grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}" $(git ls-files -mo --exclude-standard)))
         for file in ${delete_files[@]}; do
           rm "$file"
         done
@@ -54,8 +41,8 @@ runs:
       uses: peter-evans/create-pull-request@v5
       env:
         OWNER_NAME: ${{ steps.set-owner.outputs.OWNER_NAME }}
-        ENTRY_ID: ${{ steps.find-entry.outputs.ENTRY_ID }}
-        PREVIEW_URL: ${{ steps.find-entry.outputs.PREVIEW_URL }}
+        ENTRY_ID: ${{ steps.set-entry-variables.outputs.ENTRY_ID }}
+        PREVIEW_URL: ${{ steps.set-entry-variables.outputs.PREVIEW_URL }}
       with:
         title: ${{ github.event.inputs.title }}
         branch: draft-entry-${{ env.ENTRY_ID }}

--- a/.github/actions/pull-draft-by-title/action.yaml
+++ b/.github/actions/pull-draft-by-title/action.yaml
@@ -17,13 +17,20 @@ runs:
     - name: find entry
       id: find-entry
       run: |
-        entry=$(grep -xl "Title: ${{ inputs.title }}" $(git ls-files -o --exclude-standard))
-        if [[ -z "$entry" ]]; then
+        files=($(git ls-files -o --exclude-standard))
+        for file in ${files[@]}; do
+          title=$(yq --front-matter=extract '.Title' "$file")
+          if [[ "$title" == ${{ inputs.title }} ]]; then
+            entry_path="$file"
+          fi
+        done
+        if [[ -z "$entry_path" ]]; then
           echo "Error: No draft entry titled ${{ inputs.title }} was found"
           exit 1
         fi
-        echo "ENTRY_ID=$(yq --front-matter=extract '.EditURL' "$entry" | grep -oP '[^/]+\d$')" >> $GITHUB_OUTPUT
-        echo "PREVIEW_URL=$(yq --front-matter=extract '.PreviewURL'  "$entry")" >> $GITHUB_OUTPUT
+        echo "EDIT_URL=$(yq --front-matter=extract '.EditURL' "$entry_path")" >> $GITHUB_OUTPUT
+        echo "ENTRY_ID=$(yq --front-matter=extract '.EditURL' "$entry_path" | grep -oP '[^/]+\d$')" >> $GITHUB_OUTPUT
+        echo "PREVIEW_URL=$(yq --front-matter=extract '.PreviewURL' "$entry_path")" >> $GITHUB_OUTPUT
       shell: bash
     - name: set owner
       id: set-owner
@@ -36,7 +43,7 @@ runs:
       shell: bash
     - name: delete other files
       run: |
-        delete_files=($(grep -xL "Title: ${{ inputs.title }}" $(git ls-files -mo --exclude-standard)))
+        delete_files=($(grep -xL "EditURL: ${{ steps.find-entry.outputs.EDIT_URL }}" $(git ls-files -mo --exclude-standard)))
         for file in ${delete_files[@]}; do
           rm "$file"
         done

--- a/.github/workflows/create-draft.yaml
+++ b/.github/workflows/create-draft.yaml
@@ -31,10 +31,16 @@ jobs:
         env:
           TITLE: ${{ inputs.title }}
       - name: post draft to hatenablog
+        id: post-draft
         run: |
-          blogsync post --draft ${{ inputs.BLOG_DOMAIN }} < 'draft'
+          entry_path=$(blogsync post --draft ${{ inputs.BLOG_DOMAIN }} < 'draft')
+          echo "ENTRY_PATH=$entry_path" >> $GITHUB_OUTPUT
+      - name: pull
+        run: |
+          blogsync pull ${{ inputs.BLOG_DOMAIN }}
       - name: pull draft by title
         uses: hatena/hatenablog-workflows/.github/actions/pull-draft-by-title@v1
         with:
           title: ${{ inputs.title }}
           BLOG_DOMAIN: ${{ inputs.BLOG_DOMAIN }}
+          ENTRY_PATH: ${{ steps.post-draft.outputs.ENTRY_PATH }}

--- a/.github/workflows/create-draft.yaml
+++ b/.github/workflows/create-draft.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           blogsync pull ${{ inputs.BLOG_DOMAIN }}
       - name: pull draft by title
-        uses: hatena/hatenablog-workflows/.github/actions/pull-draft-by-title@v1
+        uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@v1
         with:
           title: ${{ inputs.title }}
           BLOG_DOMAIN: ${{ inputs.BLOG_DOMAIN }}

--- a/.github/workflows/pull-draft.yaml
+++ b/.github/workflows/pull-draft.yaml
@@ -24,8 +24,27 @@ jobs:
           fetch-depth: 0
       - name: setup
         uses: hatena/hatenablog-workflows/.github/actions/setup@v1
+      - name: pull
+        run: |
+          blogsync pull ${{ inputs.BLOG_DOMAIN }}
+      - name: set entry path
+        id: set-entry-path
+        run: |
+          files=($(git ls-files -o --exclude-standard))
+          for file in ${files[@]}; do
+            title=$(yq --front-matter=extract '.Title' "$file")
+            if [[ "$title" == ${{ inputs.title }} ]]; then
+              entry_path="$file"
+            fi
+          done
+          if [[ -z "$entry_path" ]]; then
+            echo "Error: No draft entry titled ${{ inputs.title }} was found"
+            exit 1
+          fi
+          echo "ENTRY_PATH=$entry_path" >> $GITHUB_OUTPUT
       - name: pull draft by title
         uses: hatena/hatenablog-workflows/.github/actions/pull-draft-by-title@v1
         with:
           title: ${{ inputs.title }}
           BLOG_DOMAIN: ${{ inputs.BLOG_DOMAIN }}
+          ENTRY_PATH: ${{ steps.set-entry-path.outputs.ENTRY_PATH }}

--- a/.github/workflows/pull-draft.yaml
+++ b/.github/workflows/pull-draft.yaml
@@ -43,7 +43,7 @@ jobs:
           fi
           echo "ENTRY_PATH=$entry_path" >> $GITHUB_OUTPUT
       - name: pull draft by title
-        uses: hatena/hatenablog-workflows/.github/actions/pull-draft-by-title@v1
+        uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@v1
         with:
           title: ${{ inputs.title }}
           BLOG_DOMAIN: ${{ inputs.BLOG_DOMAIN }}


### PR DESCRIPTION
## 背景

- `create-draft`や`pull-draft`アクションを実施する際にタイトルからファイルを取得する処理があるが, 数値のみのタイトル等の場合などでダブルクォートが含まれるとファイルをうまく取得できずエラーになるため修正を図る

## 実装内容

- `create-draft`
  - entry_path をtitleから取得せずに`blogsync post`の返り値から取得する形に変更
- `pull-draft`
  - 従来どおりtitleから取得する形に変更(将来的に変更する可能性はあるが現時点では従来と同じ形に)
- 共通アクション
  - entry_pathは本アクション内で取得していたがそれぞれで取得方法が変わったため, 引数として受け取る形に変更＆action名を変更した