### PR TITLE
blogsyncのバージョンをv0.18.2にする

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: setup blogsync
       uses: x-motemen/blogsync@v0
       with:
-        version: latest
+        version: v0.18.2
     - name: restore mtime
       run: |
         git restore-mtime


### PR DESCRIPTION
blogsync v0.19.0が出ているが、下書きエントリのファイル位置が変更されるようになっていて、hatenablog-workflowsの想定とあわなくなっている。
https://github.com/x-motemen/blogsync/releases/tag/v0.19.0

hatenablog-workflowsで対応できるまで一旦バージョンをv0.19.0の一個前にしておく