### PR TITLE
空白を含むタイトルであっても pull draft を実行可能とする

### DIFF
--- a/.github/workflows/pull-draft.yaml
+++ b/.github/workflows/pull-draft.yaml
@@ -38,7 +38,7 @@ jobs:
           files=($(git ls-files -o --exclude-standard))
           for file in ${files[@]}; do
             title=$(yq --front-matter=extract '.Title' "$file")
-            if [[ "$title" == ${{ inputs.title }} ]]; then
+            if [[ "$title" == "${{ inputs.title }}" ]]; then
               entry_path="$file"
             fi
           done


### PR DESCRIPTION
https://github.com/hatena/Hatena-Blog-Workflows-Boilerplate/ を用いて、pull draft などを実行して下書きの pull-request を作成可能にして利用しています。

pull draft を実行する際に、下書きのタイトルに空白が含まれている場合に以下のようなエラーが発生します。

```
Run files=($(git ls-files -o --exclude-standard))
  files=($(git ls-files -o --exclude-standard))
  for file in ${files[@]}; do
    title=$(yq --front-matter=extract '.Title' "$file")
    if [[ "$title" == HatenaBlog Workflows *** ]]; then
      entry_path="$file"
    fi
(snip)
/home/runner/work/_temp/8777282b-d24b-4430-a0ec-040dccafc5d3.sh: line 4: syntax error in conditional expression
```

*** はまだ公開前のためマスクした文字列です。

タイトルにはどうしても空白が含まれることがあるのと、仮のタイトルを設定して pull draft してからタイトルを正式に書き換えるというのも二度手間なので、空白が含まれていても実行に成功してほしいです。

とりあえず、shell で文字列比較を行う際に double quote で囲むだけでよさそうなので修正してみました。