### PR TITLE
git管理下にあるファイルはrmではなくgit restoreする

### DIFF
--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -29,9 +29,14 @@ runs:
       shell: bash
     - name: delete other files
       run: |
-        delete_files=($(grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}" $(git ls-files -mo --exclude-standard)))
+        delete_files=($(grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}" $(git ls-files -o --exclude-standard)))
         for file in ${delete_files[@]}; do
           rm "$file"
+        done
+
+        restore_files=($(grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}" $(git ls-files -m --exclude-standard)))
+        for file in ${resotre_files[@]}; do
+          git restore "$file"
         done
       shell: bash
     - name: move draft and update metadata


### PR DESCRIPTION
- issue: https://github.com/hatena/Hatena-Blog-Workflows-Boilerplate/issues/21

git管理下にあるファイルもrmしてしまっているので、 git管理下にあるかどうかで rmとgit restoreを使い分けるようにしてみました