### PR TITLE
delete other filesの処理を修正

### DIFF
--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -30,12 +30,12 @@ runs:
     - name: delete other files
       run: |
         set +e
-        delete_files=$(git ls-files -o --exclude-standard | xargs grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
+        delete_files=$(git ls-files -o --exclude-standard | xargs -r grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
         for file in ${delete_files[@]}; do
           rm "$file"
         done
 
-        restore_files=(git ls-files -m --exclude-standard | xargs grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
+        restore_files=(git ls-files -m --exclude-standard | xargs -r grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
         for file in ${restore_files[@]}; do
           git restore "$file"
         done

--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -29,7 +29,7 @@ runs:
       shell: bash
     - name: delete other files
       run: |
-        set +e
+        set +eo pipefail
         delete_files=$(git ls-files -o --exclude-standard | xargs -r grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
         for file in ${delete_files[@]}; do
           rm "$file"
@@ -39,6 +39,7 @@ runs:
         for file in ${restore_files[@]}; do
           git restore "$file"
         done
+      shell: bash
     - name: move draft and update metadata
       uses: hatena/hatenablog-workflows/.github/actions/move-draft-and-update-metadata@v1
     - name: create pull request

--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -30,12 +30,12 @@ runs:
     - name: delete other files
       run: |
         set +eo pipefail
-        delete_files=$(git ls-files -o --exclude-standard | xargs -r grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
+        delete_files=($(git ls-files -o --exclude-standard | xargs -r grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}"))
         for file in ${delete_files[@]}; do
           rm "$file"
         done
 
-        restore_files=(git ls-files -m --exclude-standard | xargs -r grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
+        restore_files=($(git ls-files -m --exclude-standard | xargs -r grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}"))
         for file in ${restore_files[@]}; do
           git restore "$file"
         done

--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -29,16 +29,16 @@ runs:
       shell: bash
     - name: delete other files
       run: |
-        delete_files=($(grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}" $(git ls-files -o --exclude-standard)))
+        set +e
+        delete_files=$(git ls-files -o --exclude-standard | xargs grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
         for file in ${delete_files[@]}; do
           rm "$file"
         done
 
-        restore_files=($(grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}" $(git ls-files -m --exclude-standard)))
-        for file in ${resotre_files[@]}; do
+        restore_files=(git ls-files -m --exclude-standard | xargs grep -xL "EditURL: ${{ steps.set-entry-variables.outputs.EDIT_URL }}")
+        for file in ${restore_files[@]}; do
           git restore "$file"
         done
-      shell: bash
     - name: move draft and update metadata
       uses: hatena/hatenablog-workflows/.github/actions/move-draft-and-update-metadata@v1
     - name: create pull request


### PR DESCRIPTION
https://github.com/hatena/hatenablog-workflows/pull/45 の修正が不完全だったので追い修正です

- `grep -xL "EditURL" $(git ls-files)` 形式だと、 `git ls-files` の結果がなかったときgrepがstdinから読もうとしてしまいそうなので`xargs -r`を利用するように（`-r` は `--no-run-if-empty` の短縮形）
- grepはマッチしなかったときにステータスコードを0以外にするので `-e` と `-o pipefail` をなしに
- typo修正