### PR TITLE
upload-imagesアクションを追加

### DIFF
--- a/.github/workflows/push-draft.yaml
+++ b/.github/workflows/push-draft.yaml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   push-draft:
-    if: always()
-    needs: upload-image
     runs-on: ubuntu-latest
     env:
       BLOGSYNC_PASSWORD: ${{ secrets.OWNER_API_KEY }}
@@ -33,7 +31,3 @@ jobs:
               blogsync push "$file"
             fi
           done
-  upload-image:
-    uses: hatena/hatenablog-workflows/.github/workflows/upload-images.yaml@upload-images
-    secrets:
-      OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}

--- a/.github/workflows/push-draft.yaml
+++ b/.github/workflows/push-draft.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   push-draft:
+    if: always()
+    needs: upload-image
     runs-on: ubuntu-latest
     env:
       BLOGSYNC_PASSWORD: ${{ secrets.OWNER_API_KEY }}
@@ -31,3 +33,7 @@ jobs:
               blogsync push "$file"
             fi
           done
+  upload-image:
+    uses: hatena/hatenablog-workflows/.github/workflows/upload-images.yaml@upload-images
+    secrets:
+      OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}

--- a/.github/workflows/upload-images.yaml
+++ b/.github/workflows/upload-images.yaml
@@ -29,13 +29,13 @@ jobs:
           echo "OWNER_ID=$owner" >> $GITHUB_OUTPUT
       - name: Download the script
         run: |
-          curl -o $PWD/fotolife-client.py https://raw.githubusercontent.com/hatena/hatenablog-workflows/upload-images/fotolife-client.py
-          chmod +x $PWD/fotolife-client.py
+          curl -o /tmp/fotolife-client.py https://raw.githubusercontent.com/hatena/hatenablog-workflows/upload-images/fotolife-client.py
+          chmod +x /tmp/fotolife-client.py
       - name: List all changed files markdown files
         if: steps.changed-entries.outputs.any_changed == 'true'
         run: |
           for f in ${{ steps.changed-entries.outputs.all_changed_files }}; do
-            python3 $PWD/fotolife-client.py "$f"
+            python3 /tmp/fotolife-client.py "$f"
           done
         env:
           HATENA_ID: ${{ steps.set-owner.outputs.OWNER_ID }}

--- a/.github/workflows/upload-images.yaml
+++ b/.github/workflows/upload-images.yaml
@@ -1,0 +1,53 @@
+name: "[Reusable workflows] upload images"
+
+on:
+  workflow_call:
+    secrets:
+      OWNER_API_KEY:
+        required: true
+
+jobs:
+  upload-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: list changed entries
+        id: changed-entries
+        uses: tj-actions/changed-files@v40
+        with:
+          files: |
+            **.md
+      - name: set owner
+        id: set-owner
+        run: |
+          owner=$(yq "..|.owner|select(.)" blogsync.yaml)
+          if [[ -z "$owner" ]]; then
+            owner=$(yq "..|.username|select(.)" blogsync.yaml)
+          fi
+          echo "OWNER_ID=$owner" >> $GITHUB_OUTPUT
+      - name: Download the script
+        run: |
+          curl -o $PWD/fotolife-client.py https://raw.githubusercontent.com/hatena/hatenablog-workflows/upload-images/fotolife-client.py
+          chmod +x $PWD/fotolife-client.py
+      - name: List all changed files markdown files
+        if: steps.changed-entries.outputs.any_changed == 'true'
+        run: |
+          for f in ${{ steps.changed-entries.outputs.all_changed_files }}; do
+            python3 $PWD/fotolife-client.py "$f"
+          done
+        env:
+          HATENA_ID: ${{ steps.set-owner.outputs.OWNER_ID }}
+          OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}
+      - name: commit & push
+        run: |
+          git config user.name "actions-user"
+          git config user.email "action@github.com"
+          if [[ $(git diff) -eq 0 ]]; then
+            exit 0
+          fi
+
+          git add .
+          git commit -m "upload images to fotolife"
+          git push

--- a/.github/workflows/upload-images.yaml
+++ b/.github/workflows/upload-images.yaml
@@ -29,7 +29,7 @@ jobs:
           echo "OWNER_ID=$owner" >> $GITHUB_OUTPUT
       - name: Download the script
         run: |
-          curl -o /tmp/fotolife-client.py https://raw.githubusercontent.com/hatena/hatenablog-workflows/upload-images/fotolife-client.py
+          curl -o /tmp/fotolife-client.py https://raw.githubusercontent.com/hatena/hatenablog-workflows/v1/fotolife-client.py
           chmod +x /tmp/fotolife-client.py
       - name: List all changed files markdown files
         if: steps.changed-entries.outputs.any_changed == 'true'

--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -8,7 +8,7 @@ import secrets
 import mimetypes
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
-import xml.etree.ElementTree as ElementTree
+from xml.etree import ElementTree
 
 ATOM_TEMPLATE = """
 POST /atom/post
@@ -20,7 +20,13 @@ POST /atom/post
 </entry>
 """
 
+wsse_value = ""
+base_dir = ""
+
 def wsse(username, api_key):
+    """
+    ユーザのIDとAPIキーからX-WSSEヘッダの値を生成する
+    """
     nonce = sha1(secrets.token_bytes(16)).digest()
     now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S") + "Z"
     digest = sha1(nonce + now.encode() + api_key.encode()).digest()
@@ -31,57 +37,92 @@ def wsse(username, api_key):
         now,
     )
 
-def upload_to_fotolife(match):
-    alt, path, _, _ = match.groups()
-
-    # pathがローカルのファイルを指していなければ何もしない
-    path = os.path.join(base_dir, path)
-    if not os.path.exists(path):
-        return match[0]
-
+def upload_to_fotolife(path: str) -> str|None:
+    """
+    画像のパスを受け取って、その画像ファイルをFotolifeにアップロードする
+    その画像をFotolife記法として埋め込むための文字列を返す。
+    """
     mime = mimetypes.guess_type(path)[0]
     with open(path, "rb") as f:
         imgbuf = f.read()
 
     body = ATOM_TEMPLATE.format(mime, b64encode(imgbuf).decode())
     req = Request("https://f.hatena.ne.jp/atom/post", method="POST", headers={
-        "X-WSSE": wsseValue,
+        "X-WSSE": wsse_value,
     }, data=body.encode())
     try:
         with urlopen(req) as res:
             if not 200 <= res.status < 300:
-                print("[-] failed to request: {}, reason: {}".format(res.url, res.reason))
-                return match[0]
+                print(f"[-] failed to request: {res.url}, reason: {res.reason}")
+                return None
 
             resbuf = res.read()
             tree = ElementTree.fromstring(resbuf)
             ns = {
                 "hatena": "http://www.hatena.ne.jp/info/xmlns#"
             }
-            urls = tree.findall("hatena:syntax", ns)
-            url = urls[0].text
-            print("[+] uploaded {}".format(path))
+            syntaxes = tree.findall("hatena:syntax", ns)
+            syntax = syntaxes[0].text
+            print(f"[+] uploaded {path}")
+            return syntax
     except HTTPError as e:
-        print(e)
+        print(f"[-] failed to request: {e.url}, reason: {e.reason}")
+        return None
+
+
+def replace_to_fotolife_syntax(match):
+    """
+    Markdownの画像記法で参照されている画像をFotolifeにアップロードしつつ、Fotolife記法に置き換える
+    """
+    alt = match.group("alt")
+    path = match.group("path")
+    title = match.group("title")
+
+    # pathがローカルのファイルを指していなければ何もしない
+    path = os.path.join(base_dir, path)
+    if not os.path.exists(path):
         return match[0]
 
+    syntax = upload_to_fotolife(path)
+    if syntax is None:
+        return match[0]
 
-    if not alt:
-        return "[{}]".format(url)
-    else:
-        return "[{}:title={}]".format(url, alt)
+    if alt and title:
+        return f"[{syntax}:title={title}:alt={alt}]"
+    elif (not alt) and title:
+        return f"[{syntax}:title={title}]"
+    elif alt and (not title):
+        return f"[{syntax}:alt={alt}]"
+    elif (not alt) and (not title):
+        return f"[{syntax}]"
 
-if len(sys.argv) == 1:
-    print("Usage: {} <file>".format(sys.argv[0]))
-    exit(1)
+def main():
+    """
+    usage: python3 fotolife-client.py <file>
+    """
+    global wsse_value
+    global base_dir
 
-wsseValue = wsse(os.getenv("HATENA_ID"), os.getenv("OWNER_API_KEY"))
 
-target = sys.argv[1]
-buf = open(target, "r").read()
-base_dir = os.path.dirname(target)
-pattern = re.compile(r"""!\[([^\]]*)\]\(([^\)]*)\s*(?:"([^"]*)"\s*)?(?:"([^"]*)"\s*)?\)""")
+    hatena_id = os.getenv("HATENA_ID")
+    owner_api_key = os.getenv("OWNER_API_KEY")
+    if not hatena_id or not owner_api_key:
+        print("please set environment variables: HATENA_ID, OWNER_API_KEY")
+        sys.exit(1)
+    wsse_value = wsse(hatena_id, owner_api_key)
 
-res = pattern.sub(upload_to_fotolife, buf)
-with open(target, "w") as f:
-    f.write(res)
+    if len(sys.argv) == 1:
+        print(f"usage: python3 {sys.argv[0]} <file>")
+        sys.exit(1)
+    target = sys.argv[1]
+    with open(target, "r", encoding="utf-8") as f:
+        buf = f.read()
+    base_dir = os.path.dirname(target)
+
+    pattern = re.compile(r"""!\[(?P<alt>[^\]]*)\]\((?P<path>[^\)]*)\s*(?P<title>"(?:[^"]*)"\s*)\)""")
+    res = pattern.sub(upload_to_fotolife, buf)
+    with open(target, "w", encoding="utf-8") as f:
+        f.write(res)
+
+if __name__ == "__main__":
+    main()

--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -80,6 +80,9 @@ def replace_to_fotolife_syntax(match: re.Match) -> str:
 
     # pathがローカルのファイルを指していなければ何もしない
     path = os.path.join(base_dir, path)
+    print(match)
+    print(base_dir)
+    print(path)
     if not os.path.exists(path):
         return match[0]
 

--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -70,7 +70,7 @@ def upload_to_fotolife(path: str) -> str|None:
         return None
 
 
-def replace_to_fotolife_syntax(match):
+def replace_to_fotolife_syntax(match: re.Match) -> str:
     """
     Markdownの画像記法で参照されている画像をFotolifeにアップロードしつつ、Fotolife記法に置き換える
     """
@@ -120,7 +120,7 @@ def main():
     base_dir = os.path.dirname(target)
 
     pattern = re.compile(r"""!\[(?P<alt>[^\]]*)\]\((?P<path>[^\)]*)\s*(?P<title>"(?:[^"]*)"\s*)\)""")
-    res = pattern.sub(upload_to_fotolife, buf)
+    res = pattern.sub(replace_to_fotolife_syntax, buf)
     with open(target, "w", encoding="utf-8") as f:
         f.write(res)
 

--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -1,0 +1,87 @@
+import sys
+import re
+import os
+from hashlib import sha1
+from base64 import b64encode
+from datetime import datetime
+import secrets
+import mimetypes
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+import xml.etree.ElementTree as ElementTree
+
+ATOM_TEMPLATE = """
+POST /atom/post
+
+<entry xmlns="http://purl.org/atom/ns#">
+  <title>uploaded by fotolife-client.py</title>
+  <content mode="base64" type="{}">{}</content>
+  <generator>fotolife-client.py</generator>
+</entry>
+"""
+
+def wsse(username, api_key):
+    nonce = sha1(secrets.token_bytes(16)).digest()
+    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+    digest = sha1(nonce + now.encode() + api_key.encode()).digest()
+    return 'UsernameToken Username="{}", PasswordDigest="{}", Nonce="{}", Created="{}"'.format(
+        username,
+        b64encode(digest).decode(),
+        b64encode(nonce).decode(),
+        now,
+    )
+
+def upload_to_fotolife(match):
+    alt, path, _, _ = match.groups()
+
+    # pathがローカルのファイルを指していなければ何もしない
+    path = os.path.join(base_dir, path)
+    if not os.path.exists(path):
+        return match[0]
+
+    mime = mimetypes.guess_type(path)[0]
+    with open(path, "rb") as f:
+        imgbuf = f.read()
+
+    body = ATOM_TEMPLATE.format(mime, b64encode(imgbuf).decode())
+    req = Request("https://f.hatena.ne.jp/atom/post", method="POST", headers={
+        "X-WSSE": wsseValue,
+    }, data=body.encode())
+    try:
+        with urlopen(req) as res:
+            if not 200 <= res.status < 300:
+                print("[-] failed to request: {}, reason: {}".format(res.url, res.reason))
+                return match[0]
+
+            resbuf = res.read()
+            tree = ElementTree.fromstring(resbuf)
+            ns = {
+                "hatena": "http://www.hatena.ne.jp/info/xmlns#"
+            }
+            urls = tree.findall("hatena:syntax", ns)
+            url = urls[0].text
+            print("[+] uploaded {}".format(path))
+    except HTTPError as e:
+        print(e)
+        return match[0]
+
+
+    if not alt:
+        return "[{}]".format(url)
+    else:
+        return "[{}:title={}]".format(url, alt)
+
+if len(sys.argv) == 1:
+    print("Usage: {} <file>".format(sys.argv[0]))
+    exit(1)
+
+wsseValue = wsse(os.getenv("HATENA_ID"), os.getenv("OWNER_API_KEY"))
+
+target = sys.argv[1]
+buf = open(target, "r").read()
+base_dir = os.path.dirname(target)
+pattern = re.compile(r"""!\[([^\]]*)\]\(([^\)]*)\s*(?:"([^"]*)"\s*)?(?:"([^"]*)"\s*)?\)""")
+
+res = pattern.sub(upload_to_fotolife, buf)
+with open(target, "w") as f:
+    f.write(res)

--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -119,7 +119,7 @@ def main():
         buf = f.read()
     base_dir = os.path.dirname(target)
 
-    pattern = re.compile(r"""!\[(?P<alt>[^\]]*)\]\((?P<path>[^\)]*?)\s*(?P<quot>"(?:[^"]*)"\s*)?(?P<squot>'(?:[^']*)'\s*)?\)""")
+    pattern = re.compile(r"""!\[(?P<alt>[^\]]*)\]\((?P<path>[^\)]*?)\s*("(?P<quot>[^"]*)"\s*)?('(?P<squot>[^']*)'\s*)?\)""")
     res = pattern.sub(replace_to_fotolife_syntax, buf)
     with open(target, "w", encoding="utf-8") as f:
         f.write(res)

--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -80,9 +80,6 @@ def replace_to_fotolife_syntax(match: re.Match) -> str:
 
     # pathがローカルのファイルを指していなければ何もしない
     path = os.path.join(base_dir, path)
-    print(match)
-    print(base_dir)
-    print(path)
     if not os.path.exists(path):
         return match[0]
 
@@ -122,7 +119,7 @@ def main():
         buf = f.read()
     base_dir = os.path.dirname(target)
 
-    pattern = re.compile(r"""!\[(?P<alt>[^\]]*)\]\((?P<path>[^\)]*)\s*(?P<title>"(?:[^"]*)"\s*)\)""")
+    pattern = re.compile(r"""!\[(?P<alt>[^\]]*)\]\((?P<path>[^\)]*?)\s*(?P<title>"(?:[^"]*)"\s*)\)""")
     res = pattern.sub(replace_to_fotolife_syntax, buf)
     with open(target, "w", encoding="utf-8") as f:
         f.write(res)

--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -76,7 +76,7 @@ def replace_to_fotolife_syntax(match: re.Match) -> str:
     """
     alt = match.group("alt")
     path = match.group("path")
-    title = match.group("title")
+    title = match.group("quot") or match.group("squot")
 
     # pathがローカルのファイルを指していなければ何もしない
     path = os.path.join(base_dir, path)
@@ -119,7 +119,7 @@ def main():
         buf = f.read()
     base_dir = os.path.dirname(target)
 
-    pattern = re.compile(r"""!\[(?P<alt>[^\]]*)\]\((?P<path>[^\)]*?)\s*(?P<title>"(?:[^"]*)"\s*)\)""")
+    pattern = re.compile(r"""!\[(?P<alt>[^\]]*)\]\((?P<path>[^\)]*?)\s*(?P<quot>"(?:[^"]*)"\s*)?(?P<squot>'(?:[^']*)'\s*)?\)""")
     res = pattern.sub(replace_to_fotolife_syntax, buf)
     with open(target, "w", encoding="utf-8") as f:
         f.write(res)


### PR DESCRIPTION
- .github/actions/upload-images.yamlを追加しました
 - fotolife-client.py を呼び出して、記事中の画像を自動的にはてなフォトライフにアップロードし、記法を変換するアクションです
- push時などで自動的に呼び出すようにする予定だが、先にアクションだけマージして動作確認できるようにします
