### PR TITLE
create-draft時のタイトルの埋め込みでタイトルをYAMLの値としてエスケープする

### DIFF
--- a/.github/workflows/create-draft.yaml
+++ b/.github/workflows/create-draft.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: hatena/hatenablog-workflows/.github/actions/setup@v1
       - name: setup draft
         run: |
-          envsubst < draft.template > draft
+          yq --front-matter="process" ".Title=strenv(TITLE)" draft.template > draft
         env:
           TITLE: ${{ inputs.title }}
       - name: set blog domain


### PR DESCRIPTION
- https://github.com/hatena/Hatena-Blog-Workflows-Boilerplate/issues/26 の修正です
- https://github.com/hatena/hatenablog-workflows/pull/51 だとダブルクオートやシングルクオートを含んだタイトルのときやはり壊れてしまいそうなので、yamlの文字列としていい感じにエスケープする部分をyqにお願いしてみます