### PR TITLE
内部で利用するblogsyncのバージョンをv0.20.1にアップデート

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: setup blogsync
       uses: x-motemen/blogsync@v0
       with:
-        version: v0.18.2
+        version: v0.20.1
     - name: restore mtime
       run: |
         git restore-mtime


### PR DESCRIPTION
breaking changeは無いので動作確認ができたら上げて良いはず