### PR TITLE
下書き作成(create-draft-action)時にblogsync fetchを使うように変更する

### DIFF
--- a/.github/workflows/create-draft.yaml
+++ b/.github/workflows/create-draft.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "ENTRY_PATH=$entry_path" >> "$GITHUB_OUTPUT"
       - name: pull
         run: |
-          blogsync pull ${{ steps.set-domain.outputs.BLOG_DOMAIN }}
+          blogsync fetch ${{ steps.post-draft.outputs.ENTRY_PATH }}
       - name: pull draft by title
         uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@v1
         with:

--- a/.github/workflows/create-draft.yaml
+++ b/.github/workflows/create-draft.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           entry_path=$(blogsync post --draft ${{ steps.set-domain.outputs.BLOG_DOMAIN }} < 'draft')
           echo "ENTRY_PATH=$entry_path" >> "$GITHUB_OUTPUT"
-      - name: pull
+      - name: fetch entry
         run: |
           blogsync fetch ${{ steps.post-draft.outputs.ENTRY_PATH }}
       - name: pull draft by title


### PR DESCRIPTION
- https://github.com/hatena/hatenablog-workflows/issues/59 の対応
- create-draft action にて blogsync pull している箇所を blogsync fetch に変更する