### PR TITLE
changed-draft-filesのfileをmdファイルに限定する

### DIFF
--- a/.github/workflows/push-draft.yaml
+++ b/.github/workflows/push-draft.yaml
@@ -26,7 +26,7 @@ jobs:
         id: changed-draft-files
         uses: tj-actions/changed-files@v43
         with:
-          files: draft_entries/**
+          files: draft_entries/**/*.md
       - name: push only draft entry
         run: |
           for file in ${{ steps.changed-draft-files.outputs.all_changed_files }}; do

--- a/.github/workflows/push-when-publishing-from-draft.yaml
+++ b/.github/workflows/push-when-publishing-from-draft.yaml
@@ -28,7 +28,7 @@ jobs:
         id: changed-draft-files
         uses: tj-actions/changed-files@v43
         with:
-          files: draft_entries/**
+          files: draft_entries/**/*.md
           since_last_remote_commit: true
       - name: blogsync push and delete file
         id: publised-from-draft

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -28,7 +28,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v43
         with:
-          files: ${{ inputs.local_root }}/**
+          files: ${{ inputs.local_root }}/**/*.md
           since_last_remote_commit: true
       - name: blogsync push
         run: |


### PR DESCRIPTION
- mdファイル以外の差分があった場合に失敗してしまうことがあるので対象ファイルをフィルタした