### PR TITLE
画像アップロード時のgenerator名にリポジトリを入れておく

### DIFF
--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -16,7 +16,7 @@ POST /atom/post
 <entry xmlns="http://purl.org/atom/ns#">
   <title>uploaded by fotolife-client.py</title>
   <content mode="base64" type="{}">{}</content>
-  <generator>fotolife-client.py</generator>
+  <generator>hatena/hatenablog-workflows</generator>
 </entry>
 """
 


### PR DESCRIPTION
fotolife-client.py ではなんのことかわからないので、 hatena/hatenablog-workflows を入れてアップロード元のスクリプトの場所がユーザからわかるようにしました