### PR TITLE
PullRequestをDraftで作成するかどうかを呼び出し元で選択できるようにする

### DIFF
--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -3,6 +3,8 @@ name: create draft pull request
 inputs:
   title:
     required: true
+  draft:
+    required: true
   BLOG_DOMAIN:
     required: true
   ENTRY_PATH:
@@ -57,4 +59,4 @@ runs:
           - 編集ページのURL: https://blog.hatena.ne.jp/${{ env.OWNER_NAME }}/${{ inputs.BLOG_DOMAIN }}/edit?entry=${{ env.ENTRY_ID }}
           - プレビューへのURL: ${{ env.PREVIEW_URL == 'null' && 'なし' || env.PREVIEW_URL }}
         delete-branch: true
-        draft: true
+        draft: ${{ inputs.draft == 'true' }}

--- a/.github/workflows/create-draft.yaml
+++ b/.github/workflows/create-draft.yaml
@@ -6,6 +6,9 @@ on:
       title:
         required: true
         type: string
+      draft:
+        default: true
+        type: boolean
       BLOG_DOMAIN:
         required: true
         type: string
@@ -47,5 +50,6 @@ jobs:
         uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@v1
         with:
           title: ${{ inputs.title }}
+          draft: ${{ inputs.draft }}
           BLOG_DOMAIN: ${{ steps.set-domain.outputs.BLOG_DOMAIN }}
           ENTRY_PATH: ${{ steps.post-draft.outputs.ENTRY_PATH }}

--- a/.github/workflows/pull-draft.yaml
+++ b/.github/workflows/pull-draft.yaml
@@ -6,6 +6,9 @@ on:
       title:
         required: true
         type: string
+      draft:
+        default: true
+        type: boolean
       BLOG_DOMAIN:
         required: true
         type: string
@@ -52,5 +55,6 @@ jobs:
         uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@v1
         with:
           title: ${{ inputs.title }}
+          draft: ${{ inputs.draft }}
           BLOG_DOMAIN: ${{ steps.set-domain.outputs.BLOG_DOMAIN }}
           ENTRY_PATH: ${{ steps.set-entry-path.outputs.ENTRY_PATH }}


### PR DESCRIPTION
- https://github.com/hatena/hatenablog-workflows/pull/80 にて下書き記事を作成する Workflow では Draft Pull Request がデフォルトで作成されるように変更した
- しかし、Draft Pull Request は Github の一部のプランでしか利用ができないため対応していないプランの場合、Pull Request が作成できない
- この回避策として、Reusable Workflow の呼び出し元でオプションを渡せるように修正する