### PR TITLE
画像ファイルが見つからなかった時のログを表示する

### DIFF
--- a/fotolife-client.py
+++ b/fotolife-client.py
@@ -81,6 +81,7 @@ def replace_to_fotolife_syntax(match: re.Match) -> str:
     # pathがローカルのファイルを指していなければ何もしない
     path = os.path.join(base_dir, path)
     if not os.path.exists(path):
+        print(f"[-] Skipped: file not found: {path}")
         return match[0]
 
     syntax = upload_to_fotolife(path)


### PR DESCRIPTION
本文に画像リンクを記載したが、GitHub Actionsによってフォトライフへのアップロードが行われなかった際にデバッグしやすくする。

具体的にはVisual Studio Codeのプレビュー機能では"/image/hoge.png"のようなOSのパスとしては不適切な表記でも画像が表示されるが、fotolife-client.pyでは処理がスキップされて混乱した。

"Skipped: file not found"のメッセージによってパスが怪しいことに気づける可能性が高くなると考える。

Fix #91 