### PR TITLE
fix: create-draft may not work without workflow_dispatch or workflow_call event type.

### DIFF
--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -51,10 +51,10 @@ runs:
         ENTRY_ID: ${{ steps.set-entry-variables.outputs.ENTRY_ID }}
         PREVIEW_URL: ${{ steps.set-entry-variables.outputs.PREVIEW_URL }}
       with:
-        title: ${{ github.event.inputs.title }}
+        title: ${{ inputs.title }}
         branch: draft-entry-${{ env.ENTRY_ID }}
         body: |
-          ## ${{ github.event.inputs.title }}
+          ## ${{ inputs.title }}
 
           - 編集ページのURL: https://blog.hatena.ne.jp/${{ env.OWNER_NAME }}/${{ inputs.BLOG_DOMAIN }}/edit?entry=${{ env.ENTRY_ID }}
           - プレビューへのURL: ${{ env.PREVIEW_URL == 'null' && 'なし' || env.PREVIEW_URL }}


### PR DESCRIPTION
## 概要

`create-draft-pull-request`アクションが`workflow_dispatch`や`workflow_call`以外の方法で呼び出されても、自身のアクションに指定された`inputs.title`を利用するように修正します。

## 詳細

`create-draft-pull-request`アクションは`title`を入力として受け取ることを期待しているようです。

```yaml
name: create draft pull request

inputs:
  title:
    required: true
```

しかし実装はアクションで受け取った`inputs.title`ではなく、ワークフローで受け取った`github.event.inputs.title`を直接指定していました。

これにより`create-draft-pull-request`は、おおもとの呼び出し元であるワークフロー(ユーザーリポジトリの`create-draft.yaml`)が`workflow_dispatch`(あるいは`workflow_call`)で呼ばれ、かつワークフローで`inputs.title`を受け取った時しか機能していません。

## 実際の動作

呼び出し元ワークフローで`uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request`に指定したtitleが無視される。呼び出し元ワークフローが`inputs.title`を持っているときだけ動作する。

## 期待する挙動

呼び出し元ワークフローで`uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request`に指定したtitleを使ってほしい。

## 再現例

`workflow_call`の`inputs.title`を消して、直接titleを指定すると動作しないことがわかります。

```
# これは機能しない (例)
# 例えばtitleを受け取らず直接指定すると動かない
on:
  workflow_call:
# ...省略

jobs:
  post_draft_and_pull_from_hatenablog:
    # ... 省略
    - name: pull draft by title
      uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@1e932419b6749d6b4ad3d0e30d07df87a1ed3c3e # v1
      with:
        title: "タイトルを直接指定" # これができない
        draft: ${{ inputs.draft }}
        BLOG_DOMAIN: ${{ steps.set-domain.outputs.BLOG_DOMAIN }}
        ENTRY_PATH: ${{ steps.post-draft.outputs.ENTRY_PATH }}
```
