### PR TITLE
外部のactionのバージョンをフル指定する

### DIFF
--- a/.github/actions/create-draft-pull-request/action.yaml
+++ b/.github/actions/create-draft-pull-request/action.yaml
@@ -43,7 +43,7 @@ runs:
         done
       shell: bash
     - name: move draft and update metadata
-      uses: hatena/hatenablog-workflows/.github/actions/move-draft-and-update-metadata@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+      uses: hatena/hatenablog-workflows/.github/actions/move-draft-and-update-metadata@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
     - name: get pull request template
       id: get-pull-request-template
       env:
@@ -79,7 +79,7 @@ runs:
         echo "EOF" >> $GITHUB_OUTPUT
       shell: bash
     - name: create draft pull request
-      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
       with:
         title: ${{ inputs.title }}
         branch: draft-entry-${{ steps.set-entry-variables.outputs.ENTRY_ID }}

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,7 +8,7 @@ runs:
         sudo apt-get install -y git-restore-mtime
       shell: bash
     - name: setup blogsync
-      uses: x-motemen/blogsync@9760a4c471a07ca7d471dd9f09ecbb258f6da6b0 # v0
+      uses: x-motemen/blogsync@9760a4c471a07ca7d471dd9f09ecbb258f6da6b0 # v0.20.1
       with:
         version: v0.20.1
     - name: restore mtime

--- a/.github/workflows/create-draft.yaml
+++ b/.github/workflows/create-draft.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup
-        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
       - name: setup draft
         run: |
           yq --front-matter="process" ".Title=strenv(TITLE)" draft.template > draft
@@ -47,7 +47,7 @@ jobs:
         run: |
           blogsync fetch ${{ steps.post-draft.outputs.ENTRY_PATH }}
       - name: pull draft by title
-        uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
         with:
           title: ${{ inputs.title }}
           draft: ${{ inputs.draft }}

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup
-        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
       - name: set blog domain
         id: set-domain
         run: |
@@ -34,7 +34,7 @@ jobs:
           blogsync pull ${{ steps.set-domain.outputs.BLOG_DOMAIN }}
       - name: move draft and update metadata
         if: inputs.is_draft_included == true
-        uses: hatena/hatenablog-workflows/.github/actions/move-draft-and-update-metadata@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/move-draft-and-update-metadata@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
       - name: delete draft files
         if: inputs.is_draft_included == false
         run: |

--- a/.github/workflows/pull-draft.yaml
+++ b/.github/workflows/pull-draft.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup
-        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
       - name: set blog domain
         id: set-domain
         run: |
@@ -52,7 +52,7 @@ jobs:
           fi
           echo "ENTRY_PATH=$entry_path" >> $GITHUB_OUTPUT
       - name: pull draft by title
-        uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/create-draft-pull-request@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
         with:
           title: ${{ inputs.title }}
           draft: ${{ inputs.draft }}

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup
-        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
       - name: set blog domain
         id: set-domain
         run: |

--- a/.github/workflows/push-draft.yaml
+++ b/.github/workflows/push-draft.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   upload-images:
-    uses: hatena/hatenablog-workflows/.github/workflows/upload-images.yaml@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+    uses: hatena/hatenablog-workflows/.github/workflows/upload-images.yaml@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
     secrets:
       OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}
   push-draft:
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ needs.upload-images.result == 'success' && needs.upload-images.outputs.revision || '' }}
           fetch-depth: 0
       - name: setup
-        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
       - name: Get changed draft files
         id: changed-draft-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5

--- a/.github/workflows/push-published-entries.yaml
+++ b/.github/workflows/push-published-entries.yaml
@@ -9,6 +9,6 @@ on:
 jobs:
   upload-images:
     if: github.event.pull_request.merged == false
-    uses: hatena/hatenablog-workflows/.github/workflows/upload-images.yaml@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+    uses: hatena/hatenablog-workflows/.github/workflows/upload-images.yaml@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
     secrets:
       OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}

--- a/.github/workflows/push-when-publishing-from-draft.yaml
+++ b/.github/workflows/push-when-publishing-from-draft.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup
-        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
       - name: Get changed draft files
         id: changed-draft-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup
-        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2
+        uses: hatena/hatenablog-workflows/.github/actions/setup@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5


### PR DESCRIPTION
 - 現在外部のGitHubActionは、ハッシュで指定しているがバージョンを省略して指定しているため、Renovateなどの恩恵を受けづらいので、フル指定したい
 - 参考: [GitHub Actionsの外部Actionのバージョンをhash指定しつつ、可読性を維持しつつバージョンを上げる - Hatena Developer Blog](https://developer.hatenastaff.com/entry/2025/03/17/200642)