### PR TITLE
push-when-publishing-from-draft で未使用の step id を削除

### DIFF
--- a/.github/workflows/push-when-publishing-from-draft.yaml
+++ b/.github/workflows/push-when-publishing-from-draft.yaml
@@ -31,7 +31,6 @@ jobs:
           files: draft_entries/**/*.md
           since_last_remote_commit: true
       - name: blogsync push
-        id: publised-from-draft
         run: |
           for file in ${{ steps.changed-draft-files.outputs.all_changed_files }}; do
             draft=$(yq --front-matter=extract 'select(.Draft == true)' "$file")


### PR DESCRIPTION
いつもはてなブログには大変お世話になっています。

`publised` という typo を見つけて修正しようとしましたが、この step id は参照されていなかったため、修正ではなく削除しました。（他のワークフロー含めて、参照されていない step id は無さそうでしたので、修正して残すではなく削除いたしました。）

お手数ですが、ご確認お願いします🙏 